### PR TITLE
chore: ignore root specs/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.github
 /.claude
 /.specify
+/specs
 
 # Python
 __pycache__/


### PR DESCRIPTION
Ignore root `/specs` directory for local spec-kit project work, matching existing pattern for `/.claude`, `/.github`, `/.specify`.