### PR TITLE
fix: version output and agent-specific validation

### DIFF
--- a/src/lite_kits/cli.py
+++ b/src/lite_kits/cli.py
@@ -51,7 +51,7 @@ def print_help_hint():
 def print_version_info():
     """Print version information."""
     console.print(f"[bold]Version:[/bold]")
-    console.print(f"  [bold cyan]{APP_NAME} version {__version__}[/bold cyan]\n")
+    console.print(f"  [bold cyan]{APP_NAME} version {__version__}[/bold cyan]")
 
 def print_quick_start():
     console.print("[bold]Quick Start:[/bold]")
@@ -101,7 +101,6 @@ def version_callback(value: bool):
     if value:
         console.print()
         print_version_info()
-        console.print()
         raise typer.Exit()
 
 @app.callback(invoke_without_command=True)

--- a/src/lite_kits/core/validator.py
+++ b/src/lite_kits/core/validator.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict
 
 from .manifest import KitManifest
+from .detector import Detector
 
 
 class Validator:
@@ -23,6 +24,7 @@ class Validator:
         """
         self.target_dir = target_dir
         self.manifest = manifest
+        self.detector = Detector(target_dir, manifest)
 
     def validate_all(self) -> Dict:
         """
@@ -75,14 +77,48 @@ class Validator:
                 "message": f"{kit_info['name']}: not installed",
             }
 
-        # Kit is installed, validate files
+        # Detect which agents are actually present in the project
+        detected_agents = self.detector.detect_agents()
+        detected_shells = self.detector.detect_shells()
+
+        # Kit is installed, validate only files for detected agents/shells that actually have kit files
+        files_to_validate = []
+
+        # Add agent-specific files (commands/prompts) - only if at least one kit file exists for that agent
+        for agent in detected_agents:
+            agent_files = self.manifest.get_kit_files(kit_name, agent=agent)
+            # Check if any of this kit's files exist for this agent
+            has_kit_files = any(
+                (self.target_dir / f['path']).exists()
+                for f in agent_files
+                if f.get('status') != 'planned'
+            )
+            if has_kit_files:
+                files_to_validate.extend(agent_files)
+
+        # Add shell-specific files (scripts) - only if at least one kit file exists for that shell
+        for shell in detected_shells:
+            shell_files = self.manifest.get_kit_files(kit_name, agent=shell)
+            has_kit_files = any(
+                (self.target_dir / f['path']).exists()
+                for f in shell_files
+                if f.get('status') != 'planned'
+            )
+            if has_kit_files:
+                files_to_validate.extend(shell_files)
+
+        # Add agent/shell-agnostic files (memory, templates, etc.)
         all_files = self.manifest.get_kit_files(kit_name, agent=None)
+        for file_info in all_files:
+            # Only add files that aren't agent/shell-specific
+            if file_info.get('type') not in ['command', 'prompt', 'script']:
+                files_to_validate.append(file_info)
 
         missing = []
         corrupted = []
         outdated = []
 
-        for file_info in all_files:
+        for file_info in files_to_validate:
             # Skip non-required files
             if not file_info.get('required', True):
                 continue


### PR DESCRIPTION
## Summary
Fixes two bugs found during v0.3.1 testing:

### Fixed
1. **Version output trailing newlines**: Removed extra trailing newlines from `--version` output for cleaner display
2. **Agent-specific validation**: Validation now only checks kit files for agents that actually have kit files installed

### Details

**Version Output:**
- Before: `lite-kits version 0.3.1\n\n` (extra newline)
- After: `lite-kits version 0.3.1` (clean)

**Validation Logic:**
- Problem: Validation detected both Claude and Copilot agents, then expected dev-kit files for BOTH, even when dev-kit was only installed for one agent
- Solution: Check if any kit files exist for each detected agent before validating. Only validate agents that have kit files installed.
- Example: User has `.claude/` (spec-kit only) and `.github/prompts/` (spec-kit + dev-kit) → validation now only checks dev-kit files in `.github/prompts/`, ignores `.claude/`

### Testing
- ✅ `lite-kits --version` shows clean output
- ✅ `lite-kits validate` passes when dev-kit installed for Copilot only (not Claude)
- ✅ Local installation and validation working correctly

---

Related to v0.3.1 release testing. Will bump to v0.3.2 after merge.